### PR TITLE
Return http dump request for out going request

### DIFF
--- a/client.go
+++ b/client.go
@@ -136,9 +136,11 @@ func parameterToJson(obj interface{}) (string, error) {
 }
 
 // callAPI do the request.
-func (c *APIClient) callAPI(request *http.Request) (*http.Response, error) {
+func (c *APIClient) callAPI(request *http.Request, dumpOutGoingRequest *string) (*http.Response, error) {
 	if c.cfg.Debug {
 		dump, err := httputil.DumpRequestOut(request, true)
+		dumpString := string(dump)
+		dumpOutGoingRequest = &dumpString
 		if err != nil {
 			return nil, err
 		}

--- a/http_builder.go
+++ b/http_builder.go
@@ -32,6 +32,7 @@ type builder struct {
 	localVarQueryParams      _neturl.Values
 	localVarFormParams       _neturl.Values
 	localVarHTTPContentTypes []string
+	dumpRequestOut           *string
 }
 
 func (a *service) Builder(uri string, acceptHeader ...string) *builder {
@@ -247,6 +248,13 @@ func (b *builder) UseApplicationXML() *builder {
 	return b
 }
 
+func (b *builder) DumbOutRequest(requestString *string) *builder {
+	dumpString := ""
+	b.dumpRequestOut = &dumpString
+	requestString = b.dumpRequestOut
+	return b
+}
+
 func (b *builder) Call(ctx _context.Context, response interface{}, parserCustom ...ParserCustomHandle) (*_nethttp.Response, error) {
 	localVarPath := b.a.client.cfg.BasePath + b.uri
 	localVarHTTPContentType := selectHeaderContentType(b.localVarHTTPContentTypes)
@@ -259,12 +267,14 @@ func (b *builder) Call(ctx _context.Context, response interface{}, parserCustom 
 	if localVarHTTPHeaderAccept != "" {
 		b.localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
 	}
+
 	r, err := b.a.client.prepareRequest(ctx, localVarPath, b.localVarHTTPMethod, b.localVarPostBody, b.localVarHeaderParams, b.localVarQueryParams, b.localVarFormParams, b.localVarFormFileName, b.localVarFileName, b.localVarFileBytes)
 	if err != nil {
 		return nil, err
 	}
 
-	localVarHTTPResponse, err := b.a.client.callAPI(r)
+	localVarHTTPResponse, err := b.a.client.callAPI(r, b.dumpRequestOut)
+
 	if err != nil || localVarHTTPResponse == nil {
 		return localVarHTTPResponse, err
 	}


### PR DESCRIPTION
**Why do we have this PR ?:**
My team needs to return the OutGoingClientRequest String from this lib for business needs.
Right now `http-builder` is logging OutGoingClientRequest for each request using `glog`. Without returning this information to the client which uses this lib to make HTTP calls, we are not able to store the HTTP request information in order to troubleshoot errors in the future.